### PR TITLE
#200: bind server-side vars to ${Hole}s

### DIFF
--- a/WebSharper.UI.CSharp.Templating/CodeGenerator.fs
+++ b/WebSharper.UI.CSharp.Templating/CodeGenerator.fs
@@ -180,11 +180,11 @@ let varsClass (ctx: Ctx) =
                 match holeDef.Kind with
                 | HoleKind.Var AST.ValTy.Any
                 | HoleKind.Var AST.ValTy.String ->
-                    yield sprintf """[Inline] public Var<string> %s => (Var<string>)instance.Hole("%s");""" holeName holeName'
+                    yield sprintf """[Inline] public Var<string> %s => (Var<string>)TemplateHole.Value(instance.Hole("%s"));""" holeName holeName'
                 | HoleKind.Var AST.ValTy.Number ->
-                    yield sprintf """[Inline] public Var<float> %s => (Var<float>)instance.Hole("%s");""" holeName holeName'
+                    yield sprintf """[Inline] public Var<float> %s => (Var<float>)TemplateHole.Value(instance.Hole("%s"));""" holeName holeName'
                 | HoleKind.Var AST.ValTy.Bool ->
-                    yield sprintf """[Inline] public Var<bool> %s => (Var<bool>)instance.Hole("%s");""" holeName holeName'
+                    yield sprintf """[Inline] public Var<bool> %s => (Var<bool>)TemplateHole.Value(instance.Hole("%s"));""" holeName holeName'
                 | _ -> ()
         ]
         yield "}"

--- a/WebSharper.UI.Templating.Runtime/Runtime.fs
+++ b/WebSharper.UI.Templating.Runtime/Runtime.fs
@@ -177,11 +177,11 @@ type TemplateEvent<'TI, 'E when 'E :> DomEvent> =
 
 type Handler private () =
 
-    static member EventQ (holeName: string, key: string, [<JavaScript>] f: Expr<DomElement -> DomEvent -> unit>) =
+    static member EventQ (holeName: string, [<JavaScript>] f: Expr<DomElement -> DomEvent -> unit>) =
         TemplateHole.EventQ(holeName, f)
 
     static member EventQ2<'E when 'E :> DomEvent> (key: string, holeName: string, ti: (unit -> TemplateInstance), [<JavaScript>] f: Expr<TemplateEvent<obj, 'E> -> unit>) =
-        Handler.EventQ(holeName, key, <@ fun el ev ->
+        Handler.EventQ(holeName, <@ fun el ev ->
             let k = key
             (WebSharper.JavaScript.Pervasives.As<TemplateEvent<obj, 'E> -> unit> f)
                 {

--- a/WebSharper.UI.Templating.Runtime/Runtime.fs
+++ b/WebSharper.UI.Templating.Runtime/Runtime.fs
@@ -147,8 +147,7 @@ type TemplateInitializer(id: string, vars: array<string * ValTy>) =
         member this.Initialize(_) = ()
 
         member this.PostInitialize(key) =
-            // TODO: run Bind() if it wasn't run yet
-            ()
+            Client.Doc.RunFullDocTemplate [] |> ignore
 
 and [<JavaScript>] TemplateInstances() =
     [<JavaScript>]

--- a/WebSharper.UI.Templating.Runtime/RuntimeClient.fs
+++ b/WebSharper.UI.Templating.Runtime/RuntimeClient.fs
@@ -209,11 +209,11 @@ type private RuntimeProxy =
 type private HandlerProxy =
 
     [<Inline>]
-    static member EventQ (holeName: string, isGenerated: bool, f: Expr<Dom.Element -> Dom.Event -> unit>) =
-        TemplateHole.EventQ(holeName, isGenerated, f)
+    static member EventQ (holeName: string, key: string, f: Expr<Dom.Element -> Dom.Event -> unit>) =
+        TemplateHole.EventQ(holeName, f)
 
     static member EventQ2<'E when 'E :> DomEvent> (key: string, holeName: string, ti: (unit -> TemplateInstance), [<JavaScript>] f: Expr<TemplateEvent<obj, 'E> -> unit>) =
-        TemplateHole.EventQ(holeName, true, <@ fun el ev ->
+        TemplateHole.EventQ(holeName, <@ fun el ev ->
             (%f) {
                     Vars = box (ti())
                     Target = el
@@ -222,36 +222,26 @@ type private HandlerProxy =
         @>)
 
     [<JavaScript>]
-    static member CompleteHoles(_: string, filledHoles: seq<TemplateHole>, vars: array<string * Server.ValTy>) : seq<TemplateHole> * Server.CompletedHoles =
-        let allVars = Dictionary<string, obj>()
+    static member CompleteHoles(key: string, filledHoles: seq<TemplateHole>, vars: array<string * Server.ValTy>) : seq<TemplateHole> * Server.CompletedHoles =
+        let allVars = Dictionary<string, TemplateHole>()
         let filledVars = HashSet()
         for h in filledHoles do
-            match h with
-            | TemplateHole.VarStr(n, Box r)
-            | TemplateHole.VarIntUnchecked(n, Box r)
-            | TemplateHole.VarInt(n, Box r)
-            | TemplateHole.VarFloatUnchecked(n, Box r)
-            | TemplateHole.VarFloat(n, Box r)
-            | TemplateHole.VarBool(n, Box r) ->
-                filledVars.Add n |> ignore
-                allVars.[n] <- r
-            | _ -> ()
+            let n = TemplateHole.Name h
+            filledVars.Add(n) |> ignore
+            allVars.[n] <- h
         let extraHoles =
             vars |> Array.choose (fun (name, ty) ->
                 if filledVars.Contains name then None else
-                let h, r =
+                let r =
                     match ty with
                     | Server.ValTy.String ->
-                        let r = Var.Create ""
-                        TemplateHole.VarStr (name, r), box r
+                        Server.TemplateInitializer.GetOrAddHoleFor(key, name, fun () -> TemplateHole.VarStr (name, Var.Create ""))
                     | Server.ValTy.Number ->
-                        let r = Var.Create 0.
-                        TemplateHole.VarFloatUnchecked (name, r), box r
+                        Server.TemplateInitializer.GetOrAddHoleFor(key, name, fun () -> TemplateHole.VarFloatUnchecked (name, Var.Create 0.))
                     | Server.ValTy.Bool ->
-                        let r = Var.Create false
-                        TemplateHole.VarBool (name, r), box r
+                        Server.TemplateInitializer.GetOrAddHoleFor(key, name, fun () -> TemplateHole.VarBool (name, Var.Create false))
                     | _ -> failwith "Invalid value type"
                 allVars.[name] <- r
-                Some h
+                Some r
             )
         Seq.append filledHoles extraHoles, Server.CompletedHoles.Client(allVars)

--- a/WebSharper.UI.Templating.ServerSide.Tests/Main.fs
+++ b/WebSharper.UI.Templating.ServerSide.Tests/Main.fs
@@ -56,6 +56,14 @@ module Client =
             .ClientSide(div [] [text "[OK] Inserted using Bind()"])
             .Bind()
 
+let mkServerVarForm() =
+    MainTemplate.Main.ServerVarForm()
+        .ServerClick(fun t ->
+            JavaScript.JS.Alert("Hello, " + !t.Vars.ServerVar + "! The input should now clear itself.")
+            t.Vars.ServerVar := ""
+        )
+        .Doc()
+
 [<Website>]
 let Main = Application.SinglePage(fun ctx ->
     Content.Page(
@@ -105,6 +113,7 @@ let Main = Application.SinglePage(fun ctx ->
                         )
                     :> Doc
                 ])
+            .ServerVarForms([mkServerVarForm(); mkServerVarForm()])
             .AfterRender(fun () -> Client.OnStartup())
             .TBody([MainTemplate.Main.Row().Doc(); MainTemplate.Main.Row().Doc()])
             .Elt(keepUnfilled = true)

--- a/WebSharper.UI.Templating.ServerSide.Tests/Main.html
+++ b/WebSharper.UI.Templating.ServerSide.Tests/Main.html
@@ -30,6 +30,17 @@
             <tr ws-template="Row"><td>Table row</td></tr>
         </tbody>
     </table>
+    <hr/>
+
+    The following inputs should NOT be bound together:
+    <hr/>
+    <div ws-replace="ServerVarForms" ws-template="ServerVarForm">
+        <input ws-var="ServerVar" />
+        <div style="color: ${ServerVar}">Hello, ${ServerVar}! (try typing a color name, this text should become this color)</div>
+        <button ws-onclick="ServerClick">Click me!</button>
+        <hr/>
+    </div>
+
     <div ws-replace="Client"></div>
     <div style="display:none">
         <div data-template="OldTemplate">

--- a/WebSharper.UI.Templating/TemplatingProvider.fs
+++ b/WebSharper.UI.Templating/TemplatingProvider.fs
@@ -311,13 +311,13 @@ module private Impl =
                 let holeName' = holeName.ToLowerInvariant()
                 match def.Kind with
                 | AST.HoleKind.Var AST.ValTy.Any | AST.HoleKind.Var AST.ValTy.String ->
-                    yield ProvidedProperty(holeName, typeof<Var<string>>, fun x -> <@@ ((%%x.[0] : obj) :?> TI).Hole holeName' @@>)
+                    yield ProvidedProperty(holeName, typeof<Var<string>>, fun x -> <@@ ((%%x.[0] : obj) :?> TI).Hole holeName' |> TemplateHole.Value @@>)
                         .WithXmlDoc(XmlDoc.Member.Var holeName)
                 | AST.HoleKind.Var AST.ValTy.Number ->
-                    yield ProvidedProperty(holeName, typeof<Var<float>>, fun x -> <@@ ((%%x.[0] : obj) :?> TI).Hole holeName' @@>)
+                    yield ProvidedProperty(holeName, typeof<Var<float>>, fun x -> <@@ ((%%x.[0] : obj) :?> TI).Hole holeName' |> TemplateHole.Value @@>)
                         .WithXmlDoc(XmlDoc.Member.Var holeName)
                 | AST.HoleKind.Var AST.ValTy.Bool ->
-                    yield ProvidedProperty(holeName, typeof<Var<bool>>, fun x -> <@@ ((%%x.[0] : obj) :?> TI).Hole holeName' @@>)
+                    yield ProvidedProperty(holeName, typeof<Var<bool>>, fun x -> <@@ ((%%x.[0] : obj) :?> TI).Hole(holeName') |> TemplateHole.Value @@>)
                         .WithXmlDoc(XmlDoc.Member.Var holeName)
                 | _ -> ()
         ]

--- a/WebSharper.UI/Attr.Client.fsi
+++ b/WebSharper.UI/Attr.Client.fsi
@@ -164,3 +164,29 @@ module internal Attrs =
 
     /// Get OnAfterRender callback, if any.
     val GetOnAfterRender : Dyn -> option<Dom.Element -> unit>
+
+module BindVar =
+    type Set<'a> = Dom.Element -> 'a -> unit
+    type Get<'a> = Dom.Element -> 'a option
+    type Apply<'a, 'o1, 'o2> = Var<'a> -> ((Dom.Element -> unit) -> 'o1) -> ((Dom.Element -> 'a -> unit) -> 'o2) -> 'o1 * 'o2
+    val StringSet : Set<string>
+    val StringGet : Get<string>
+    val StringApply<'o1, 'o2> : Apply<string, 'o1, 'o2>
+
+    val IntSetUnchecked : Set<int>
+    val IntGetUnchecked : Get<int>
+    val IntApplyUnchecked<'o1, 'o2> : Apply<int, 'o1, 'o2>
+
+    val IntSetChecked : Set<CheckedInput<int>>
+    val IntGetChecked : Get<CheckedInput<int>>
+    val IntApplyChecked<'o1, 'o2> : Apply<CheckedInput<int>, 'o1, 'o2>
+
+    val FloatSetUnchecked : Set<float>
+    val FloatGetUnchecked : Get<float>
+    val FloatApplyUnchecked<'o1, 'o2> : Apply<float, 'o1, 'o2>
+
+    val FloatSetChecked : Set<CheckedInput<float>>
+    val FloatGetChecked : Get<CheckedInput<float>>
+    val FloatApplyChecked<'o1, 'o2> : Apply<CheckedInput<float>, 'o1, 'o2>
+
+    val BoolCheckedApply<'o1, 'o2> : Apply<bool, 'o1, 'o2>

--- a/WebSharper.UI/Doc.Client.fs
+++ b/WebSharper.UI/Doc.Client.fs
@@ -88,6 +88,10 @@ module Doc =
         As (Templates.RunFullDocTemplate fillWith)
 
     [<Inline>]
+    let RegisterGlobalTemplateHole (hole: TemplateHole) : unit =
+        Templates.GlobalHoles.[TemplateHole.Name hole] <- hole
+
+    [<Inline>]
     let Run parent (doc: Doc) =
         Templates.LoadLocalTemplates ""
         Doc'.Run parent (As doc)

--- a/WebSharper.UI/Doc.Client.fsi
+++ b/WebSharper.UI/Doc.Client.fsi
@@ -80,8 +80,13 @@ module Doc =
     /// Construct a Doc using a given loaded template by name and template fillers.
     val GetOrLoadTemplate : string -> option<string> -> (unit -> Dom.Element) -> seq<TemplateHole> -> Doc
 
-    /// Run the full document as a template with the given fillers.
+    /// Run the full document as a template with the given fillers
+    /// in addition to those registered with RegisterGlobalHole.
     val RunFullDocTemplate : seq<TemplateHole> -> Doc
+
+    /// Register a hole filler to make it available in RunFullDocTemplate.
+    /// Its id should be globally unique; behavior for duplicates is unspecified.
+    val RegisterGlobalTemplateHole : TemplateHole -> unit
 
   // Collections.
 

--- a/WebSharper.UI/Doc.Client.fsi
+++ b/WebSharper.UI/Doc.Client.fsi
@@ -82,6 +82,7 @@ module Doc =
 
     /// Run the full document as a template with the given fillers
     /// in addition to those registered with RegisterGlobalHole.
+    /// If RunFullDocTemplate has alredy been run, this does nothing and re-returns the same Doc.
     val RunFullDocTemplate : seq<TemplateHole> -> Doc
 
     /// Register a hole filler to make it available in RunFullDocTemplate.

--- a/WebSharper.UI/Doc.fs
+++ b/WebSharper.UI/Doc.fs
@@ -374,7 +374,7 @@ and [<RequireQualifiedAccess; JavaScript false>] TemplateHole =
     | TextView of name: string * fillWith: View<string>
     | Attribute of name: string * fillWith: Attr
     | Event of name: string * fillWith: (Dom.Element -> Dom.Event -> unit)
-    | EventQ of name: string * isGenerated: bool * fillWith: Expr<Dom.Element -> Dom.Event -> unit>
+    | EventQ of name: string * fillWith: Expr<Dom.Element -> Dom.Event -> unit>
     | AfterRender of name: string * fillWith: (Dom.Element -> unit)
     | AfterRenderQ of name: string * fillWith: Expr<Dom.Element -> unit>
     | VarStr of name: string * fillWith: Var<string>
@@ -383,6 +383,7 @@ and [<RequireQualifiedAccess; JavaScript false>] TemplateHole =
     | VarIntUnchecked of name: string * fillWith: Var<int>
     | VarFloat of name: string * fillWith: Var<Client.CheckedInput<float>>
     | VarFloatUnchecked of name: string * fillWith: Var<float>
+    | UninitVar of name: string * key: string
 
     [<Inline>]
     static member NewActionEvent<'T when 'T :> Dom.Event>(name: string, f: Action<Dom.Element, 'T>) =
@@ -456,11 +457,50 @@ and [<RequireQualifiedAccess; JavaScript false>] TemplateHole =
         | TemplateHole.VarIntUnchecked (name, _)
         | TemplateHole.VarFloat (name, _)
         | TemplateHole.VarFloatUnchecked (name, _)
+        | TemplateHole.UninitVar (name, _)
         | TemplateHole.Event (name, _)
-        | TemplateHole.EventQ (name, _, _)
+        | TemplateHole.EventQ (name, _)
         | TemplateHole.AfterRender (name, _)
         | TemplateHole.AfterRenderQ (name, _)
         | TemplateHole.Attribute (name, _) -> name
+
+    [<Inline "$x.$1">]
+    static member Value x =
+        match x with
+        | TemplateHole.Elt (_, v) -> box v
+        | TemplateHole.Text (name, v) -> box v
+        | TemplateHole.TextView (name, v) -> box v
+        | TemplateHole.VarStr (name, v) -> box v
+        | TemplateHole.VarBool (name, v) -> box v
+        | TemplateHole.VarInt (name, v) -> box v
+        | TemplateHole.VarIntUnchecked (name, v) -> box v
+        | TemplateHole.VarFloat (name, v) -> box v
+        | TemplateHole.VarFloatUnchecked (name, v) -> box v
+        | TemplateHole.UninitVar (name, v) -> box v
+        | TemplateHole.Event (name, v) -> box v
+        | TemplateHole.EventQ (name, v) -> box v
+        | TemplateHole.AfterRender (name, v) -> box v
+        | TemplateHole.AfterRenderQ (name, v) -> box v
+        | TemplateHole.Attribute (name, v) -> box v
+
+    [<Inline "{$: $x.$, $0: $n, $1: $x.$1}">]
+    static member WithName n x =
+        match x with
+        | TemplateHole.Elt (_, v) -> TemplateHole.Elt(n, v)
+        | TemplateHole.Text (_, v) -> TemplateHole.Text(n, v)
+        | TemplateHole.TextView (_, v) -> TemplateHole.TextView(n, v)
+        | TemplateHole.VarStr (_, v) -> TemplateHole.VarStr(n, v)
+        | TemplateHole.VarBool (_, v) -> TemplateHole.VarBool(n, v)
+        | TemplateHole.VarInt (_, v) -> TemplateHole.VarInt(n, v)
+        | TemplateHole.VarIntUnchecked (_, v) -> TemplateHole.VarIntUnchecked(n, v)
+        | TemplateHole.VarFloat (_, v) -> TemplateHole.VarFloat(n, v)
+        | TemplateHole.VarFloatUnchecked (_, v) -> TemplateHole.VarFloatUnchecked(n, v)
+        | TemplateHole.UninitVar (_, v) -> TemplateHole.UninitVar(n, v)
+        | TemplateHole.Event (_, v) -> TemplateHole.Event(n, v)
+        | TemplateHole.EventQ (_, v) -> TemplateHole.EventQ(n, v)
+        | TemplateHole.AfterRender (_, v) -> TemplateHole.AfterRender(n, v)
+        | TemplateHole.AfterRenderQ (_, v) -> TemplateHole.AfterRenderQ(n, v)
+        | TemplateHole.Attribute (_, v) -> TemplateHole.Attribute(n, v)
 
 type Doc with
 

--- a/WebSharper.UI/Doc.fsi
+++ b/WebSharper.UI/Doc.fsi
@@ -553,7 +553,7 @@ type TemplateHole =
     | TextView of name: string * fillWith: View<string>
     | Attribute of name: string * fillWith: Attr
     | Event of name: string * fillWith: (Dom.Element -> Dom.Event -> unit)
-    | EventQ of name: string * isGenerated: bool * fillWith: Expr<Dom.Element -> Dom.Event -> unit>
+    | EventQ of name: string * fillWith: Expr<Dom.Element -> Dom.Event -> unit>
     | AfterRender of name: string * fillWith: (Dom.Element -> unit)
     | AfterRenderQ of name: string * fillWith: Expr<Dom.Element -> unit>
     | VarStr of name: string * fillWith: Var<string>
@@ -562,8 +562,11 @@ type TemplateHole =
     | VarIntUnchecked of name: string * fillWith: Var<int>
     | VarFloat of name: string * fillWith: Var<Client.CheckedInput<float>>
     | VarFloatUnchecked of name: string * fillWith: Var<float>
+    | UninitVar of name: string * key: string
 
     static member Name : TemplateHole -> string
+    static member Value : TemplateHole -> obj
+    static member WithName : string -> TemplateHole -> TemplateHole
 
     static member NewActionEvent<'T when 'T :> Dom.Event> : name: string * f: Action<Dom.Element, 'T> -> TemplateHole
 

--- a/WebSharper.UI/Templates.fs
+++ b/WebSharper.UI/Templates.fs
@@ -577,11 +577,19 @@ module internal Templates =
             LoadNestedTemplates JS.Document.Body ""
         LoadedTemplates.[baseName] <- LoadedTemplateFile("")
 
+    let mutable RenderedFullDocTemplate = None
+
     let RunFullDocTemplate (fillWith: seq<TemplateHole>) =
-        LoadLocalTemplates ""
-        PrepareTemplateStrict "" None JS.Document.Body None
-        ChildrenTemplate JS.Document.Body fillWith
-        |>! Doc'.RunInPlace true JS.Document.Body
+        match RenderedFullDocTemplate with
+        | Some d -> d
+        | None ->
+            let d =
+                LoadLocalTemplates ""
+                PrepareTemplateStrict "" None JS.Document.Body None
+                ChildrenTemplate JS.Document.Body fillWith
+                |>! Doc'.RunInPlace true JS.Document.Body
+            RenderedFullDocTemplate <- Some d
+            d
 
     let NamedTemplate (baseName: string) (name: option<string>) (fillWith: seq<TemplateHole>) =
         match LoadedTemplateFile(baseName).TryGetValue(defaultArg name "") with

--- a/WebSharper.UI/Templates.fs
+++ b/WebSharper.UI/Templates.fs
@@ -38,6 +38,8 @@ module internal Templates =
             d
     let mutable LocalTemplatesLoaded = false
 
+    let mutable GlobalHoles = Dictionary<string, TemplateHole>()
+
     let TextHoleRE = """\${([^}]+)}"""
 
     let InlineTemplate (el: Dom.Element) (fillWith: seq<TemplateHole>) =
@@ -126,7 +128,7 @@ module internal Templates =
                 let a = x.Split([|':'|], StringSplitOptions.RemoveEmptyEntries)
                 match fw.TryGetValue(a.[1]) with
                 | true, TemplateHole.Event (_, handler) -> Some (Attr.Handler a.[0] handler)
-                | true, TemplateHole.EventQ (_, _, handler) -> Some (A.Handler a.[0] handler)
+                | true, TemplateHole.EventQ (_, handler) -> Some (A.Handler a.[0] handler)
                 | true, _ ->
                     Console.Warn("Event hole on" + a.[0] + " filled with non-event data", a.[1])
                     None
@@ -233,6 +235,7 @@ module internal Templates =
         docTreeNode, updates
 
     let ChildrenTemplate (el: Dom.Element) (fillWith: seq<TemplateHole>) =
+        let fillWith = Seq.append fillWith GlobalHoles.Values
         let docTreeNode, updates = InlineTemplate el fillWith
         match docTreeNode.Els with
         | [| Union1Of2 e |] when e.NodeType = Dom.NodeType.Element ->

--- a/paket.lock
+++ b/paket.lock
@@ -661,13 +661,13 @@ NUGET
       System.Xml.XmlDocument (>= 4.3)
       System.Xml.XPath (>= 4.3)
   remote: https://daily.websharper.com/nuget
-    WebSharper (4.5.4.317)
-    WebSharper.CSharp (4.5.4.317)
-      WebSharper (4.5.4.317)
-    WebSharper.FSharp (4.5.4.317)
-      WebSharper (4.5.4.317)
-    WebSharper.Testing (4.5.4.317)
-      WebSharper (4.5.4.317)
+    WebSharper (4.5.5.318)
+    WebSharper.CSharp (4.5.5.318)
+      WebSharper (4.5.5.318)
+    WebSharper.FSharp (4.5.5.318)
+      WebSharper (4.5.5.318)
+    WebSharper.Testing (4.5.5.318)
+      WebSharper (4.5.5.318)
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.SDK
     src/ProvidedTypes.fs (7d57cd409d7299592822713195924e42b2b7acde)


### PR DESCRIPTION
Fixes #200.

Before this PR, a server-side var such as this:

```html
<input ws-var="MyVar" />
```

 would be rendered as something like this:

```html
<input oninput="some-generated-function-name(&quot;some-guid&quot;, &quot;MyVar&quot;)(this)(event)" />
```

This PR does the following:

* Render the above as this instead:

    ```html
    <input ws-var="some-guid::MyVar" />
    ```

* Serialize the template in `<meta>` and have its pre-initialization create the client-side Vars, find the above `ws-var`s and bind them. Also make these holes available globally to `RunFullDocTemplate` as `some-guid::MyVar`.

* Render `${MyVar}` text holes as `${some-guid::MyVar}`, so that it gets picked up by `RunFullDocTemplate`.

* During post-initialization, call `RunFullDocTemplate`. This populates all the `${some-guid::MyVar}`s, unless that was already done by the user calling a template's `.Bind()` (which calls `RunFullDocTemplate`) during initialization (eg in a Web.Control).