### PR TITLE
Fix #220: in value Attrs, check equality during View propagation

### DIFF
--- a/WebSharper.UI.Templating.Runtime/Runtime.fs
+++ b/WebSharper.UI.Templating.Runtime/Runtime.fs
@@ -59,20 +59,25 @@ type TemplateInitializer(id: string, vars: array<string * ValTy>) =
 
     static let initialized = Dictionary<string, Dictionary<string, TemplateHole>>()
 
+    static let applyTypedVarHole (bind: BindVar.Apply<'a>) (v: Var<'a>) el =
+        let init, set, view = bind v
+        init el
+        View.Sink (set el) view
+
     static let applyVarHole el tpl =
         match tpl with
         | TemplateHole.VarStr (_, v) ->
-            BindVar.StringApply v (fun f -> f el) (fun f -> View.Sink (f el) v.View) |> ignore
+            applyTypedVarHole BindVar.StringApply v el
         | TemplateHole.VarBool (_, v) ->
-            BindVar.BoolCheckedApply v (fun f -> f el) (fun f -> View.Sink (f el) v.View) |> ignore
+            applyTypedVarHole BindVar.BoolCheckedApply v el
         | TemplateHole.VarInt (_, v) ->
-            BindVar.IntApplyChecked v (fun f -> f el) (fun f -> View.Sink (f el) v.View) |> ignore
+            applyTypedVarHole BindVar.IntApplyChecked v el
         | TemplateHole.VarIntUnchecked (_, v) ->
-            BindVar.IntApplyUnchecked v (fun f -> f el) (fun f -> View.Sink (f el) v.View) |> ignore
+            applyTypedVarHole BindVar.IntApplyUnchecked v el
         | TemplateHole.VarFloat (_, v) ->
-            BindVar.FloatApplyChecked v (fun f -> f el) (fun f -> View.Sink (f el) v.View) |> ignore
+            applyTypedVarHole BindVar.FloatApplyChecked v el
         | TemplateHole.VarFloatUnchecked (_, v) ->
-            BindVar.FloatApplyUnchecked v (fun f -> f el) (fun f -> View.Sink (f el) v.View) |> ignore
+            applyTypedVarHole BindVar.FloatApplyUnchecked v el
         | TemplateHole.Elt (n, _)
         | TemplateHole.Text (n, _)
         | TemplateHole.TextView (n, _)

--- a/WebSharper.UI/Attr.Client.fsi
+++ b/WebSharper.UI/Attr.Client.fsi
@@ -169,27 +169,29 @@ module internal Attrs =
     val GetOnAfterRender : Dyn -> option<Dom.Element -> unit>
 
 module BindVar =
+    type Init = Dom.Element -> unit
     type Set<'a> = Dom.Element -> 'a -> unit
     type Get<'a> = Dom.Element -> 'a option
-    type Apply<'a, 'o1, 'o2> = Var<'a> -> ((Dom.Element -> unit) -> 'o1) -> ((Dom.Element -> 'a -> unit) -> 'o2) -> 'o1 * 'o2
+    type Apply<'a> = Var<'a> -> (Init * Set<'a option> * View<'a option>)
+
     val StringSet : Set<string>
     val StringGet : Get<string>
-    val StringApply<'o1, 'o2> : Apply<string, 'o1, 'o2>
+    val StringApply : Apply<string>
 
     val IntSetUnchecked : Set<int>
     val IntGetUnchecked : Get<int>
-    val IntApplyUnchecked<'o1, 'o2> : Apply<int, 'o1, 'o2>
+    val IntApplyUnchecked : Apply<int>
 
     val IntSetChecked : Set<CheckedInput<int>>
     val IntGetChecked : Get<CheckedInput<int>>
-    val IntApplyChecked<'o1, 'o2> : Apply<CheckedInput<int>, 'o1, 'o2>
+    val IntApplyChecked : Apply<CheckedInput<int>>
 
     val FloatSetUnchecked : Set<float>
     val FloatGetUnchecked : Get<float>
-    val FloatApplyUnchecked<'o1, 'o2> : Apply<float, 'o1, 'o2>
+    val FloatApplyUnchecked : Apply<float>
 
     val FloatSetChecked : Set<CheckedInput<float>>
     val FloatGetChecked : Get<CheckedInput<float>>
-    val FloatApplyChecked<'o1, 'o2> : Apply<CheckedInput<float>, 'o1, 'o2>
+    val FloatApplyChecked : Apply<CheckedInput<float>>
 
-    val BoolCheckedApply<'o1, 'o2> : Apply<bool, 'o1, 'o2>
+    val BoolCheckedApply : Apply<bool>


### PR DESCRIPTION
cc @cata 

This should fix the cursor jump issue by checking for equality early in the View propagation.

I was also wondering whether we should remove the check before setting the Var [here](https://github.com/dotnet-websharper/ui/blob/a70e5543a83377d07e20fdd36e4e3ae39731b624/WebSharper.UI/Attr.Client.fs#L307); but I think it's still useful to avoid doing multiple propagations because both `input` and `keypress` are triggered.