### PR TITLE
#226 - Add server side template based C# event handlers

### DIFF
--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Properties/launchSettings.json
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:11786/",
+      "sslPort": 44398
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebSharper.UI.CSharp.Tests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Routing.cs
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Routing.cs
@@ -1,0 +1,93 @@
+// $begin{copyright}
+//
+// This file is part of WebSharper
+//
+// Copyright (c) 2008-2018 IntelliFactory
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// $end{copyright}
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using WebSharper;
+using WebSharper.Sitelets;
+using static WebSharper.Sitelets.RouterOperators;
+
+namespace WebSharper.UI.CSharp.Routing.Tests
+{
+    [JavaScript, EndPoint("/")]
+    public class Root
+    {
+        public static Router<Root> Inferred = InferRouter.Router.Infer<Root>();
+
+        // hand written version
+        public static Router<Root> Defined =
+            rRoot.MapTo(Root.Instance)
+            + ("sub" / Router<int>.op_Division<string>(rInt, rString))
+                .Map(t => new About(t.Item1, t.Item2), a => (a.Id, a.Message).ToTuple())
+                .Cast<Root>();
+        // Person+Book would be even longer... 
+        // maybe some helper would be nice, to create a Router<obj[]> from an URL template string like Infer does internally and map it immediately 
+        // it would look like: Router.Create("/sub/{Id}/{Message}", a => new About() { Id = a[0], Message = a[1] }, a => new object[] { a.Id, a.Message })
+
+        public static Root Instance = new Root();
+
+        public override string ToString() => "Root";
+
+        public static Root[] TestValues =
+            new[]
+            {
+                Root.Instance,
+                new Root.About(1, "hi"),
+                new Root.About.Book(2, "hello", "T", "4")
+            };
+
+        [JavaScript, EndPoint("/sub/{Id}/{Message}")]
+        public class About : Root
+        {
+            public int Id;
+            public string Message;
+
+            public About() { }
+            public About(int i, string m) { Id = i; Message = m; }
+
+            public override string ToString() => $"About Id={Id} Message='{Message}'";
+
+            [JavaScript, EndPoint("/a/{Name}")]
+            public class Person : About
+            {
+                public string Name;
+
+                public Person() { }
+                public Person(int i, string m, string n) : base(i, m) { Name = n; }
+
+                public override string ToString() => $"About person Id={Id} Message='{Message}' Name={Name}";
+            }
+
+            //[JavaScript, EndPoint("/b/{Title}?page={Page}")] // testing without query first
+            [JavaScript, EndPoint("/b/{Title}/{Page}")] // testing without query first
+            public class Book : About
+            {
+                public string Title;
+                public string Page;
+
+                public Book() { }
+                public Book(int i, string m, string t, string p) : base(i, m) { Title = t; Page = p; }
+
+                public override string ToString() => $"About book Id={Id} Message='{Message}' Title='{Title}' Pages={Page}";
+            }
+        }
+    }
+}

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
@@ -13,20 +13,6 @@ namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
 {
     public class Site
     {
-        [JavaScript]
-        public static class Client
-        {
-            static public IControlBody ClientMain()
-            {
-                var vReversed = Var.Create("");
-                return new Template.Index.tasksTitle()
-                    .TestHole(
-                        UI.Client.Doc.Input(new List<Attr>(), vReversed)
-                    )
-                    .Doc();
-            }
-        }
-
         [EndPoint("/")]
         public class Home
         {
@@ -35,32 +21,38 @@ namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
         }
 
         [JavaScript]
-        public static void AfterRenderOverload(JavaScript.Dom.Element el) => JavaScript.Console.Log("Element", el);
+        public static void AfterRender(JavaScript.Dom.Element el) => JavaScript.Console.Log("After render initialized");
+
+        [JavaScript]
+        public static void AfterRenderAction() => JavaScript.Console.Log("After render action initialized");
 
         [JavaScript]
         public static void AfterRenderOverloadTempl(UI.Templating.Runtime.Server.TemplateEvent<Vars, JavaScript.Dom.Event> m) =>
-            m.Vars.MyVar.Set("I'm initialized");
+            m.Vars.Logger.Set("I'm initialized from after render");
 
         [JavaScript]
-        public static void ClickMeTempl(UI.Templating.Runtime.Server.TemplateEvent<Vars, JavaScript.Dom.MouseEvent> m) =>
-            m.Vars.MyVar.Set("I'm initialized from click");
+        public static void ClickMeTempl(UI.Templating.Runtime.Server.TemplateEvent<Vars, JavaScript.Dom.MouseEvent> m) => m.Vars.Logger.Set(m.Vars.Logger.Value + "\nI'm initialized from click");
 
         [JavaScript]
-        public static void ClickMe(JavaScript.Dom.Element el, JavaScript.Dom.MouseEvent ev) => JavaScript.Console.Log("Click", el);
+        public static void ClickMe(JavaScript.Dom.Element el, JavaScript.Dom.MouseEvent ev) => JavaScript.Console.Log("Click sent", el);
 
         [JavaScript]
         public static void ClickMeRev(JavaScript.Dom.MouseEvent ev, JavaScript.Dom.Element el) => JavaScript.Console.Log("Click", el);
 
         [JavaScript]
-        public static void ClickMeAction() => JavaScript.Console.Log("ClickAction");
+        public static void ClickMeAction() => JavaScript.Console.Log("Click action sent");
 
         public static Task<Content> Page()
         {
             return Content.Page(
                 new Template.Index()
                     //.DocToReplace(client(() => Client.ClientMain()))
-                    .AfterRenderFromServerFromServer((m) => AfterRenderOverloadTempl(m))
-                    .ClickMeFromServer((m) => ClickMeTempl(m))
+                    .AfterRenderTempl_Server((m) => AfterRenderOverloadTempl(m))
+                    .ClickMeTempl_Server((m) => ClickMeTempl(m))
+                    .AfterRenderUnit_Server(() => AfterRenderAction())
+                    .ClickMeUnit_Server(() => ClickMeAction())
+                    .AfterRender_Server((el) => AfterRender(el))
+                    .ClickMe_Server((el, ev) => ClickMe(el, ev))
                     .Doc()
             );
         }

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using WebSharper;
+using WebSharper.Sitelets;
+using WebSharper.UI;
+using static WebSharper.UI.Html;
+
+namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
+{
+    public class Site
+    {
+        [JavaScript]
+        public static class Client
+        {
+            static public IControlBody ClientMain()
+            {
+                var vReversed = Var.Create("");
+                return new Template.Index.tasksTitle()
+                    .TestHole(
+                        UI.Client.Doc.Input(new List<Attr>(), vReversed)
+                    )
+                    .Doc();
+            }
+        }
+
+        [EndPoint("/")]
+        public class Home
+        {
+            public override bool Equals(object obj) => obj is Home;
+            public override int GetHashCode() => 0;
+        }
+
+        [JavaScript]
+        public static void AfterRenderOverload(JavaScript.Dom.Element el) => JavaScript.Console.Log("Element", el);
+
+        public static Task<Content> Page() =>
+            Content.Page(
+                new Template.Index()
+                    //.DocToReplace(client(() => Client.ClientMain()))
+                    .AfterRenderFromServerFromServer((m) => AfterRenderOverload(m))
+                    //.ClickMeFromServer(() => JavaScript.Console.Log("Hello"))
+                    .Doc()
+            );
+
+        [Website]
+        public static Sitelet<object> Main =>
+            new SiteletBuilder()
+                .With<Home>((ctx, action) =>
+                    Page()
+                )
+                .Install();
+    }
+}

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using WebSharper;
 using WebSharper.Sitelets;
 using WebSharper.UI;
+using static WebSharper.UI.CSharp.Templating.ServerSide.Tests.Template.Index;
 using static WebSharper.UI.Html;
 
 namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
@@ -36,12 +37,21 @@ namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
         [JavaScript]
         public static void AfterRenderOverload(JavaScript.Dom.Element el) => JavaScript.Console.Log("Element", el);
 
+        [JavaScript]
+        public static void ClickMe(JavaScript.Dom.Element el, JavaScript.Dom.MouseEvent ev) => JavaScript.Console.Log("Click", el);
+
+        [JavaScript]
+        public static void ClickMeRev(JavaScript.Dom.MouseEvent ev, JavaScript.Dom.Element el) => JavaScript.Console.Log("Click", el);
+
+        [JavaScript]
+        public static void ClickMeAction() => JavaScript.Console.Log("ClickAction");
+
         public static Task<Content> Page() =>
             Content.Page(
                 new Template.Index()
                     //.DocToReplace(client(() => Client.ClientMain()))
                     .AfterRenderFromServerFromServer((m) => AfterRenderOverload(m))
-                    //.ClickMeFromServer(() => JavaScript.Console.Log("Hello"))
+                    .ClickMeFromServer((el, ev) => ClickMeRev(ev, el))
                     .Doc()
             );
 

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/Site.cs
@@ -38,6 +38,14 @@ namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
         public static void AfterRenderOverload(JavaScript.Dom.Element el) => JavaScript.Console.Log("Element", el);
 
         [JavaScript]
+        public static void AfterRenderOverloadTempl(UI.Templating.Runtime.Server.TemplateEvent<Vars, JavaScript.Dom.Event> m) =>
+            m.Vars.MyVar.Set("I'm initialized");
+
+        [JavaScript]
+        public static void ClickMeTempl(UI.Templating.Runtime.Server.TemplateEvent<Vars, JavaScript.Dom.MouseEvent> m) =>
+            m.Vars.MyVar.Set("I'm initialized from click");
+
+        [JavaScript]
         public static void ClickMe(JavaScript.Dom.Element el, JavaScript.Dom.MouseEvent ev) => JavaScript.Console.Log("Click", el);
 
         [JavaScript]
@@ -46,14 +54,16 @@ namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
         [JavaScript]
         public static void ClickMeAction() => JavaScript.Console.Log("ClickAction");
 
-        public static Task<Content> Page() =>
-            Content.Page(
+        public static Task<Content> Page()
+        {
+            return Content.Page(
                 new Template.Index()
                     //.DocToReplace(client(() => Client.ClientMain()))
-                    .AfterRenderFromServerFromServer((m) => AfterRenderOverload(m))
-                    .ClickMeFromServer((el, ev) => ClickMeRev(ev, el))
+                    .AfterRenderFromServerFromServer((m) => AfterRenderOverloadTempl(m))
+                    .ClickMeFromServer((m) => ClickMeTempl(m))
                     .Doc()
             );
+        }
 
         [Website]
         public static Sitelet<object> Main =>

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/StartUp.cs
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/StartUp.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using WebSharper.AspNetCore;
+
+namespace WebSharper.UI.CSharp.Templating.ServerSide.Tests
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSitelet(Site.Main)
+                .AddAuthentication("WebSharper")
+                .AddCookie("WebSharper", options => { });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment()) { app.UseDeveloperExceptionPage(); }
+
+            app.UseAuthentication()
+                .UseStaticFiles()
+                .UseWebSharper()
+                .Run(context =>
+                {
+                    context.Response.StatusCode = 404;
+                    return context.Response.WriteAsync("Page not found");
+                });
+        }
+
+        public static void Main(string[] args)
+        {
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build()
+                .Run();
+        }
+    }
+}

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/WebSharper.UI.CSharp.Templating.ServerSide.Tests.csproj
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/WebSharper.UI.CSharp.Templating.ServerSide.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <WebSharperUICSharpTaskAssembly>..\WebSharper.UI.CSharp.Templating.Build\bin\$(Configuration)\netstandard2.0\WebSharper.UI.CSharp.Templating.Build.dll</WebSharperUICSharpTaskAssembly>
     <NoWarn>3218;CS1591</NoWarn>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -21,9 +21,6 @@
     <ProjectReference Include="../WebSharper.UI\WebSharper.UI.fsproj" />
     <ProjectReference Include="../WebSharper.UI.CSharp\WebSharper.UI.CSharp.fsproj" />
     <ProjectReference Include="../WebSharper.UI.Templating.Runtime\WebSharper.UI.Templating.Runtime.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="WebSharper.UI.Templates\" />
   </ItemGroup>
   <Import Project="..\msbuild\WebSharper.UI.CSharp.targets" />
   <Import Project="..\.paket\Paket.Restore.targets" />

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/WebSharper.UI.CSharp.Templating.ServerSide.Tests.csproj
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/WebSharper.UI.CSharp.Templating.ServerSide.Tests.csproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <WebSharperUICSharpTaskAssembly>..\WebSharper.UI.CSharp.Templating.Build\bin\$(Configuration)\netstandard2.0\WebSharper.UI.CSharp.Templating.Build.dll</WebSharperUICSharpTaskAssembly>
+    <NoWarn>3218;CS1591</NoWarn>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="index.html" />
+    <None Include="wsconfig.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\WebSharper.UI.Templating.Common\bin\$(Configuration)\netstandard2.0\HtmlAgilityPack.dll" />
+    <Analyzer Include="..\WebSharper.UI.Templating.Common\bin\$(Configuration)\netstandard2.0\WebSharper.UI.Templating.Common.dll" />
+    <Analyzer Include="..\WebSharper.UI.CSharp.Templating\bin\$(Configuration)\netstandard2.0\WebSharper.UI.CSharp.Templating.dll" />
+    <Analyzer Include="..\WebSharper.UI.CSharp.Templating.Analyzer\bin\$(Configuration)\netstandard2.0\WebSharper.UI.CSharp.Templating.Analyzer.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../WebSharper.UI.Templating.Common\WebSharper.UI.Templating.Common.fsproj" />
+    <ProjectReference Include="../WebSharper.UI\WebSharper.UI.fsproj" />
+    <ProjectReference Include="../WebSharper.UI.CSharp\WebSharper.UI.CSharp.fsproj" />
+    <ProjectReference Include="../WebSharper.UI.Templating.Runtime\WebSharper.UI.Templating.Runtime.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="WebSharper.UI.Templates\" />
+  </ItemGroup>
+  <Import Project="..\msbuild\WebSharper.UI.CSharp.targets" />
+  <Import Project="..\.paket\Paket.Restore.targets" />
+</Project>

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/index.html
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/index.html
@@ -14,11 +14,11 @@
 </head>
 <body>
     <div id="main">
-        <h1 ws-template="tasksTitle" ws-hole="TestHole"></h1>
-        <input ws-var="MyVar" />
+        <textarea ws-var="Logger"></textarea>
     </div>
-    <div ws-replace="DocToReplace"></div>
-    <div id="tasksTitle" ws-onafterrender="AfterRenderFromServer" ws-onclick="ClickMe">Hello</div>
+    <div ws-onafterrender="AfterRender" ws-onclick="ClickMe">Click this to change 1st input</div>
+    <div ws-onafterrender="AfterRenderTempl" ws-onclick="ClickMeTempl">Click this to change 2nd input</div>
+    <div ws-onafterrender="AfterRenderUnit" ws-onclick="ClickMeUnit">Click this to change 3rd input</div>
     <script ws-replace="scripts"></script>
 </body>
 </html>

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/index.html
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/index.html
@@ -15,6 +15,7 @@
 <body>
     <div id="main">
         <h1 ws-template="tasksTitle" ws-hole="TestHole"></h1>
+        <input ws-var="MyVar" />
     </div>
     <div ws-replace="DocToReplace"></div>
     <div id="tasksTitle" ws-onafterrender="AfterRenderFromServer" ws-onclick="ClickMe">Hello</div>

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/index.html
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/index.html
@@ -1,0 +1,23 @@
+<!-- ClientLoad = FromDocument
+     ServerLoad = WhenChanged -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>WebSharper.UI.CSharp.Tests</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+        [ws-template], [ws-children-template] {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div id="main">
+        <h1 ws-template="tasksTitle" ws-hole="TestHole"></h1>
+    </div>
+    <div ws-replace="DocToReplace"></div>
+    <div id="tasksTitle" ws-onafterrender="AfterRenderFromServer" ws-onclick="ClickMe">Hello</div>
+    <script ws-replace="scripts"></script>
+</body>
+</html>

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/paket.references
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/paket.references
@@ -1,0 +1,5 @@
+WebSharper
+WebSharper.CSharp
+HtmlAgilityPack
+FSharp.Core
+WebSharper.AspNetCore

--- a/WebSharper.UI.CSharp.Templating.ServerSide.Tests/wsconfig.json
+++ b/WebSharper.UI.CSharp.Templating.ServerSide.Tests/wsconfig.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://websharper.com/wsconfig.schema.json",
+  "project": "site",
+  "outputDir": "wwwroot"
+}

--- a/WebSharper.UI.CSharp.Templating/CodeGenerator.fs
+++ b/WebSharper.UI.CSharp.Templating/CodeGenerator.fs
@@ -90,9 +90,13 @@ let buildHoleMethods (typeName: string) (holeName: HoleName) (holeDef: HoleDefin
                 s "View<string>" "TextView" "x"
             |]
         | HoleKind.ElemHandler ->
+            let eventType = "WebSharper.JavaScript.Dom.Event"
+            let argType = "WebSharper.UI.Templating.Runtime.Server.TemplateEvent<Vars, "+eventType+">"
             [|
                 s "Action<DomElement>" "AfterRender" "FSharpConvert.Fun<DomElement>(x)"
                 s "Action" "AfterRender" "FSharpConvert.Fun<DomElement>((a) => x())"
+                s ("Action<"+argType+">") "Event"
+                    ("FSharpConvert.Fun<DomElement, DomEvent>((a,b) => x(new "+argType+"(new Vars(instance), a, ("+eventType+")b)))")
             |]
         | HoleKind.Event eventType ->
             let eventType = "WebSharper.JavaScript.Dom." + eventType

--- a/WebSharper.UI.CSharp.Templating/CodeGenerator.fs
+++ b/WebSharper.UI.CSharp.Templating/CodeGenerator.fs
@@ -106,10 +106,7 @@ let buildHoleMethods (typeName: string) (holeName: HoleName) (holeDef: HoleDefin
                 yield!
                     serverS ("Expression<Action<DomElement>>") "AfterRenderE" "x"
                 yield!
-                    serverS ("Expression<Action>") "AfterRenderE" "(Expression<Action<DomElement>>)(el => x.Compile().Invoke())"
-                yield! 
-                    serverS ("Expression<Action<"+argType+">>") "AfterRenderE"
-                        ("(Expression<Action<DomElement>>) (el => x.Compile().Invoke(new "+argType+"(new Vars(instance), el, null)))")
+                    serverS ("Expression<Action>") "AfterRenderExprAction" "x"
             |]
         | HoleKind.Event eventType ->
             let eventType = "WebSharper.JavaScript.Dom." + eventType
@@ -123,10 +120,7 @@ let buildHoleMethods (typeName: string) (holeName: HoleName) (holeDef: HoleDefin
                 yield! 
                     serverS ("Expression<Action<DomElement, "+eventType+">>") "EventExpr" "x"
                 yield!
-                    serverS ("Expression<Action>") "EventE" "(Expression<Action<DomElement, DomEvent>>)((el, ev) => x.Compile().Invoke())"
-                yield!
-                    serverS ("Expression<Action<"+argType+">>") "EventExpr"
-                        ("(Expression<Action<DomElement,"+eventType+">>) ((el, ev) => x.Compile().Invoke(new "+argType+"(new Vars(instance), el, ev)))")
+                    serverS ("Expression<Action>") "EventExprAction" "x"
             |]
         | HoleKind.Simple ->
             [|

--- a/WebSharper.UI.CSharp.Tests/template.html
+++ b/WebSharper.UI.CSharp.Tests/template.html
@@ -36,7 +36,7 @@
         <h1>My TODO! list</h1>
         <div id="tasks"></div>
         <div style="display: none" ws-children-template="Main">
-            <ul class="list-unstyled" ws-hole="ListContainer">
+            <ul class="list-unstyled" ws-onafterrender="MyRenderer2" ws-hole="ListContainer">
                 <li ws-template="ListItem">
                     <div class="checkbox">
                         <label ws-attr="ShowDone">

--- a/WebSharper.UI.Templating.Runtime/Runtime.fs
+++ b/WebSharper.UI.Templating.Runtime/Runtime.fs
@@ -84,11 +84,16 @@ type TemplateInitializer(id: string, vars: array<string * ValTy>) =
         | TemplateHole.UninitVar (n, _)
         | TemplateHole.Event (n, _)
         | TemplateHole.EventQ (n, _)
+        | TemplateHole.EventE (n, _)
         | TemplateHole.AfterRender (n, _)
         | TemplateHole.AfterRenderQ (n, _)
+        | TemplateHole.AfterRenderE (n, _)
         | TemplateHole.Attribute (n, _) -> JavaScript.Console.Warn("Not a var hole: ", n)
 
     static member Initialized = initialized
+
+    [<Inline "$global.UIVarDict[$name]">]
+    static member GetServerVarInitValue (name: string) = WebSharper.JavaScript.Interop.X<string>
 
     static member GetHolesFor(id) =
         match initialized.TryGetValue(id) with
@@ -542,6 +547,10 @@ type Runtime private () =
                 dict.Add(n, Attr.HandlerImpl("", e) :> IRequiresResources)
             | TemplateHole.AfterRenderQ (n, e) ->
                 dict.Add(n, Attr.OnAfterRenderImpl(e) :> IRequiresResources)
+            | TemplateHole.EventE (n, e) ->
+                dict.Add(n, (Attr.HandlerLinq "" e) :> IRequiresResources)
+            | TemplateHole.AfterRenderE (n, e) ->
+                dict.Add(n, Attr.OnAfterRenderLinq(e) :> IRequiresResources)
             | _ -> ()
         
         fillWith |> Seq.iter (addTemplateHole requireResources)

--- a/WebSharper.UI.Templating.Runtime/Runtime.fs
+++ b/WebSharper.UI.Templating.Runtime/Runtime.fs
@@ -84,10 +84,10 @@ type TemplateInitializer(id: string, vars: array<string * ValTy>) =
         | TemplateHole.UninitVar (n, _)
         | TemplateHole.Event (n, _)
         | TemplateHole.EventQ (n, _)
-        | TemplateHole.EventE (n, _)
+        | TemplateHole.EventE (n, _, _, _)
         | TemplateHole.AfterRender (n, _)
         | TemplateHole.AfterRenderQ (n, _)
-        | TemplateHole.AfterRenderE (n, _)
+        | TemplateHole.AfterRenderE (n, _, _, _)
         | TemplateHole.Attribute (n, _) -> JavaScript.Console.Warn("Not a var hole: ", n)
 
     static member Initialized = initialized
@@ -547,10 +547,10 @@ type Runtime private () =
                 dict.Add(n, Attr.HandlerImpl("", e) :> IRequiresResources)
             | TemplateHole.AfterRenderQ (n, e) ->
                 dict.Add(n, Attr.OnAfterRenderImpl(e) :> IRequiresResources)
-            | TemplateHole.EventE (n, e) ->
-                dict.Add(n, (Attr.HandlerLinq "" e) :> IRequiresResources)
-            | TemplateHole.AfterRenderE (n, e) ->
-                dict.Add(n, Attr.OnAfterRenderLinq(e) :> IRequiresResources)
+            | TemplateHole.EventE (n, k, dep, e) ->
+                dict.Add(n, (Attr.HandlerLinqWithKey "" k dep e) :> IRequiresResources)
+            | TemplateHole.AfterRenderE (n, k, dep, e) ->
+                dict.Add(n, Attr.OnAfterRenderLinq k dep e :> IRequiresResources)
             | _ -> ()
         
         fillWith |> Seq.iter (addTemplateHole requireResources)

--- a/WebSharper.UI.Templating.Runtime/Runtime.fs
+++ b/WebSharper.UI.Templating.Runtime/Runtime.fs
@@ -34,6 +34,7 @@ open WebSharper.UI.Templating.AST
 open WebSharper.Sitelets
 open WebSharper.Sitelets.Content
 open System.Collections.Concurrent
+open WebSharper.Core
 
 module M = WebSharper.Core.Metadata
 module J = WebSharper.Core.Json
@@ -186,6 +187,12 @@ type TemplateEvent<'TI, 'E when 'E :> DomEvent> =
     }
 
 type Handler private () =
+
+    static member AfterRenderClient (holeName: string, [<JavaScript>] f : DomElement -> unit) : TemplateHole =
+        failwithf "%s overload is intended for client-side use only. Please use %sFromServer instead" holeName holeName
+
+    static member EventClient (holeName: string, [<JavaScript>] f : DomElement -> DomEvent -> unit) : TemplateHole =
+        failwithf "%s overload is intended for client-side use only. Please use %sFromServer instead" holeName holeName
 
     static member EventQ (holeName: string, [<JavaScript>] f: Expr<DomElement -> DomEvent -> unit>) =
         TemplateHole.EventQ(holeName, f)

--- a/WebSharper.UI.Templating.Runtime/RuntimeClient.fs
+++ b/WebSharper.UI.Templating.Runtime/RuntimeClient.fs
@@ -259,3 +259,24 @@ type private HandlerProxy =
                 Some r
             )
         Seq.append filledHoles extraHoles, Server.CompletedHoles.Client(allVars)
+        
+[<JavaScript>]
+type ClientTemplateInstanceHandlers =
+
+    [<JavaScriptExport>]
+    static member EventQ2Client (key: string, el: Dom.Element, ev: Dom.Event, f: obj -> unit) =
+        f
+            ({
+                Vars = box (Server.TemplateInstances.GetInstance key)
+                Target = el
+                Event = ev
+            } : TemplateEvent<_, _>)
+
+    [<JavaScriptExport>]
+    static member AfterRenderQ2Client (key: string, el: Dom.Element, f: obj -> unit) =
+        f
+            ({
+                Vars = box (Server.TemplateInstances.GetInstance key)
+                Target = el
+                Event = null
+            } : TemplateEvent<_, _>)

--- a/WebSharper.UI.Templating.Runtime/RuntimeClient.fs
+++ b/WebSharper.UI.Templating.Runtime/RuntimeClient.fs
@@ -210,6 +210,14 @@ type private RuntimeProxy =
 type private HandlerProxy =
 
     [<Inline>]
+    static member AfterRenderClient (holeName: string, [<JavaScript>] f : Dom.Element -> unit) : TemplateHole =
+        TemplateHole.AfterRender (holeName, f)
+
+    [<Inline>]
+    static member EventClient (holeName: string, [<JavaScript>] f : Dom.Element -> Dom.Event -> unit) : TemplateHole =
+        TemplateHole.Event (holeName, f)
+
+    [<Inline>]
     static member EventQ (holeName: string, f: Expr<Dom.Element -> Dom.Event -> unit>) =
         TemplateHole.EventQ(holeName, f)
 

--- a/WebSharper.UI.sln
+++ b/WebSharper.UI.sln
@@ -21,7 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{2A2EF6F0
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.CSharp", "WebSharper.UI.CSharp\WebSharper.UI.CSharp.fsproj", "{13FBA482-7285-4C83-A201-2D60FF89E586}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebSharper.UI.CSharp.Tests", "WebSharper.UI.CSharp.Tests\WebSharper.UI.CSharp.Tests.csproj", "{88079FA1-E1C8-4868-A1D0-3815BF4DABE2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSharper.UI.CSharp.Tests", "WebSharper.UI.CSharp.Tests\WebSharper.UI.CSharp.Tests.csproj", "{88079FA1-E1C8-4868-A1D0-3815BF4DABE2}"
 	ProjectSection(ProjectDependencies) = postProject
 		{AE103526-34B2-4556-914C-3E45BB1CFB17} = {AE103526-34B2-4556-914C-3E45BB1CFB17}
 		{AC8E0153-76B5-4035-991D-F7CC05439B9D} = {AC8E0153-76B5-4035-991D-F7CC05439B9D}
@@ -35,7 +35,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.Tests", "WebS
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.CSharp.Templating", "WebSharper.UI.CSharp.Templating\WebSharper.UI.CSharp.Templating.fsproj", "{B84D3163-0E80-488E-B47C-D0750859C024}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "WebSharper.UI.Templating.ServerSide.Tests", "WebSharper.UI.Templating.ServerSide.Tests\WebSharper.UI.Templating.ServerSide.Tests.fsproj", "{89FAD4A9-B3E6-442C-9080-E859719DF870}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.Templating.ServerSide.Tests", "WebSharper.UI.Templating.ServerSide.Tests\WebSharper.UI.Templating.ServerSide.Tests.fsproj", "{89FAD4A9-B3E6-442C-9080-E859719DF870}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.Templating.Common", "WebSharper.UI.Templating.Common\WebSharper.UI.Templating.Common.fsproj", "{AE103526-34B2-4556-914C-3E45BB1CFB17}"
 EndProject
@@ -46,6 +46,8 @@ EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.CSharp.Templating.Build", "WebSharper.UI.CSharp.Templating.Build\WebSharper.UI.CSharp.Templating.Build.fsproj", "{3B1280C3-1F2B-4231-9B6C-2640CA9F7A6D}"
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "WebSharper.UI.Routing.Tests", "WebSharper.UI.Routing.Tests\WebSharper.UI.Routing.Tests.fsproj", "{A0D7C6E3-E644-422C-825A-123EEBE96B03}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebSharper.UI.CSharp.Templating.ServerSide.Tests", "WebSharper.UI.CSharp.Templating.ServerSide.Tests\WebSharper.UI.CSharp.Templating.ServerSide.Tests.csproj", "{A9756638-4FBC-424F-956E-46D7EBBEA2DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -105,6 +107,10 @@ Global
 		{A0D7C6E3-E644-422C-825A-123EEBE96B03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A0D7C6E3-E644-422C-825A-123EEBE96B03}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A0D7C6E3-E644-422C-825A-123EEBE96B03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9756638-4FBC-424F-956E-46D7EBBEA2DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9756638-4FBC-424F-956E-46D7EBBEA2DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9756638-4FBC-424F-956E-46D7EBBEA2DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9756638-4FBC-424F-956E-46D7EBBEA2DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebSharper.UI/Attr.fs
+++ b/WebSharper.UI/Attr.fs
@@ -267,3 +267,16 @@ type Attr =
             | :? MethodCallExpression as e -> e.Method
             | _ -> failwithf "Invalid handler function: %A" q
         Attr.HandlerLinqImpl(event, meth, "")
+
+    static member OnAfterRenderLinqImpl(m, location, enc) =
+        let func, reqs = Attr.HandlerFallback(m, location, id)
+        DepAttr ("ws-runafterrender", func, (fun _ -> reqs), enc)
+
+    static member OnAfterRenderLinq (q: Expression<Action<Dom.Element>>) =
+        let meth =
+            match q.Body with
+            | :? MethodCallExpression as e -> e.Method
+            | _ -> failwithf "Invalid handler function: %A" q
+        let enc (meta: M.Info) (json: J.Provider) =
+            OnAfterRenderControl.Instance.Encode(meta, json)
+        Attr.OnAfterRenderLinqImpl(meth, "", enc)

--- a/WebSharper.UI/Attr.fs
+++ b/WebSharper.UI/Attr.fs
@@ -306,7 +306,7 @@ type Attr =
                 value.Value <-
                     match q.Body with
                     | :? MethodCallExpression as b when b.Arguments.Count = 0 ->
-                        let func, reqs = Attr.HandlerFallback(b.Method, "no location", id)
+                        let func, reqs = Attr.HandlerFallback(b.Method, "no location", fun s -> s + "()")
                         Some (func meta, reqs)
                     | :? MethodCallExpression as b when b.Arguments.Count = 1 ->
                         match b.Arguments[0] with

--- a/WebSharper.UI/Attr.fsi
+++ b/WebSharper.UI/Attr.fsi
@@ -63,8 +63,10 @@ type Attr =
     /// When called on the server side, the handler must be a top-level function or a static member.
     static member HandlerLinq : event: string -> callback: (System.Linq.Expressions.Expression<System.Action<Dom.Element, #Dom.Event>>) -> Attr
 
+    static member HandlerLinqWithKey : event: string -> key: string -> dep: WebSharper.IRequiresResources option-> callback: (System.Linq.Expressions.Expression<System.Action<Dom.Element, #Dom.Event>>) -> Attr
+
     static member HandlerImpl : event: string * callback: (Expr<Dom.Element -> #Dom.Event -> unit>) -> Attr
 
     static member OnAfterRenderImpl : callback: Expr<Dom.Element -> unit> -> Attr
 
-    static member OnAfterRenderLinq : callback: System.Linq.Expressions.Expression<System.Action<Dom.Element>> -> Attr
+    static member OnAfterRenderLinq : key: string -> dep: WebSharper.IRequiresResources option -> callback: System.Linq.Expressions.Expression<System.Action<Dom.Element>> -> Attr

--- a/WebSharper.UI/Attr.fsi
+++ b/WebSharper.UI/Attr.fsi
@@ -66,3 +66,5 @@ type Attr =
     static member HandlerImpl : event: string * callback: (Expr<Dom.Element -> #Dom.Event -> unit>) -> Attr
 
     static member OnAfterRenderImpl : callback: Expr<Dom.Element -> unit> -> Attr
+
+    static member OnAfterRenderLinq : callback: System.Linq.Expressions.Expression<System.Action<Dom.Element>> -> Attr

--- a/WebSharper.UI/Doc.fs
+++ b/WebSharper.UI/Doc.fs
@@ -392,7 +392,10 @@ and [<RequireQualifiedAccess; JavaScript false>] TemplateHole =
 
     [<Inline>]
     static member NewActionEvent<'T when 'T :> Dom.Event>(name: string, f: Action<Dom.Element, 'T>) =
-        Event(name, fun el ev -> f.Invoke(el, downcast ev))
+        if IsClient then
+            Event(name, fun el ev -> f.Invoke(el, downcast ev))
+        else
+            failwith <| sprintf "%s overload is intended for client-side use only. Please use %sFromServer instead" name name
 
     static member NewEventExpr<'T when 'T :> Dom.Event>(name: string, k: string, dep: IRequiresResources option, f: Expression<Action<Dom.Element, 'T>>) =
         let parameters =

--- a/WebSharper.UI/Doc.fsi
+++ b/WebSharper.UI/Doc.fsi
@@ -24,6 +24,7 @@ namespace WebSharper.UI
 
 open System
 open Microsoft.FSharp.Quotations
+open System.Linq.Expressions
 open WebSharper
 open WebSharper.JavaScript
 open WebSharper.Core.Resources
@@ -554,8 +555,10 @@ type TemplateHole =
     | Attribute of name: string * fillWith: Attr
     | Event of name: string * fillWith: (Dom.Element -> Dom.Event -> unit)
     | EventQ of name: string * fillWith: Expr<Dom.Element -> Dom.Event -> unit>
+    | EventE of name: string * fillWith: Expression<Action<Dom.Element, Dom.Event>>
     | AfterRender of name: string * fillWith: (Dom.Element -> unit)
     | AfterRenderQ of name: string * fillWith: Expr<Dom.Element -> unit>
+    | AfterRenderE of name: string * fillWith: Expression<Action<Dom.Element>>
     | VarStr of name: string * fillWith: Var<string>
     | VarBool of name: string * fillWith: Var<bool>
     | VarInt of name: string * fillWith: Var<Client.CheckedInput<int>>
@@ -569,6 +572,7 @@ type TemplateHole =
     static member WithName : string -> TemplateHole -> TemplateHole
 
     static member NewActionEvent<'T when 'T :> Dom.Event> : name: string * f: Action<Dom.Element, 'T> -> TemplateHole
+    static member NewEventExpr<'T when 'T :> Dom.Event> : name: string * f: Expression<Action<Dom.Element, 'T>> -> TemplateHole
 
     static member MakeText : name: string * text: string -> TemplateHole
 

--- a/WebSharper.UI/Doc.fsi
+++ b/WebSharper.UI/Doc.fsi
@@ -555,10 +555,10 @@ type TemplateHole =
     | Attribute of name: string * fillWith: Attr
     | Event of name: string * fillWith: (Dom.Element -> Dom.Event -> unit)
     | EventQ of name: string * fillWith: Expr<Dom.Element -> Dom.Event -> unit>
-    | EventE of name: string * fillWith: Expression<Action<Dom.Element, Dom.Event>>
+    | EventE of name: string * key: string * dep: IRequiresResources option * fillWith: Expression<Action<Dom.Element, Dom.Event>>
     | AfterRender of name: string * fillWith: (Dom.Element -> unit)
     | AfterRenderQ of name: string * fillWith: Expr<Dom.Element -> unit>
-    | AfterRenderE of name: string * fillWith: Expression<Action<Dom.Element>>
+    | AfterRenderE of name: string * key: string * dep: IRequiresResources option * fillWith: Expression<Action<Dom.Element>>
     | VarStr of name: string * fillWith: Var<string>
     | VarBool of name: string * fillWith: Var<bool>
     | VarInt of name: string * fillWith: Var<Client.CheckedInput<int>>
@@ -572,7 +572,7 @@ type TemplateHole =
     static member WithName : string -> TemplateHole -> TemplateHole
 
     static member NewActionEvent<'T when 'T :> Dom.Event> : name: string * f: Action<Dom.Element, 'T> -> TemplateHole
-    static member NewEventExpr<'T when 'T :> Dom.Event> : name: string * f: Expression<Action<Dom.Element, 'T>> -> TemplateHole
+    static member NewEventExpr<'T when 'T :> Dom.Event> : name: string * key: string * dep: IRequiresResources option * f: Expression<Action<Dom.Element, 'T>> -> TemplateHole
     static member NewEventExprAction : name: string * f: Expression<Action> -> TemplateHole
     static member NewAfterRenderExprAction : name: string * f: Expression<Action> -> TemplateHole
 

--- a/WebSharper.UI/Doc.fsi
+++ b/WebSharper.UI/Doc.fsi
@@ -573,6 +573,8 @@ type TemplateHole =
 
     static member NewActionEvent<'T when 'T :> Dom.Event> : name: string * f: Action<Dom.Element, 'T> -> TemplateHole
     static member NewEventExpr<'T when 'T :> Dom.Event> : name: string * f: Expression<Action<Dom.Element, 'T>> -> TemplateHole
+    static member NewEventExprAction : name: string * f: Expression<Action> -> TemplateHole
+    static member NewAfterRenderExprAction : name: string * f: Expression<Action> -> TemplateHole
 
     static member MakeText : name: string * text: string -> TemplateHole
 

--- a/paket.lock
+++ b/paket.lock
@@ -494,4 +494,4 @@ GROUP wsbuild
 
 GIT
   remote: https://github.com/dotnet-websharper/build-script
-     (3f1320b6f18c663fd395803eb79409ad102231ac)
+     (f028af07cf019553ae078fef9afc3706aa16c98c)

--- a/paket.lock
+++ b/paket.lock
@@ -494,4 +494,4 @@ GROUP wsbuild
 
 GIT
   remote: https://github.com/dotnet-websharper/build-script
-     (f028af07cf019553ae078fef9afc3706aa16c98c)
+     (727cf341e559695debe9821be6044e8f29d8d64c)


### PR DESCRIPTION
Add server side event handler overloads for:

-  `Action` and `Action<Dom.Element, Dom.Event>` for on* events
-  `Action` and `Action<Dom.Element>` for OnAfterRender
