### PR TITLE
#84 - Fix issue with File array indexing

### DIFF
--- a/WebSharper.UI/Attr.Client.fs
+++ b/WebSharper.UI/Attr.Client.fs
@@ -348,7 +348,7 @@ module BindVar =
         () // This should do nothing, as we should not override the values from the input
     let FileGetUnchecked : Get<File array> = fun el ->
         let files : FileList = el?files
-        [| for i in 1..files.Length do yield files.Item(i) |] |> Some
+        [| for i in 0..files.Length-1 do yield files.Item(i) |] |> Some
     let FileApplyUnchecked : Apply<File array> =
         ApplyValue FileGetUnchecked FileSetUnchecked
 


### PR DESCRIPTION
This PR addresses the issue of the `Var<File array>`'s getter, by fixing it's indexing.